### PR TITLE
Polish pass: typos, grammar, non-idiomatic language, and consistency

### DIFF
--- a/draft-ietf-dnsop-dnssec-automation.xml
+++ b/draft-ietf-dnsop-dnssec-automation.xml
@@ -31,6 +31,7 @@
 		<title abbrev="DNSSEC automation">DNSSEC automation</title>
 
 		<author fullname="Ulrich Wisser" initials="U" surname="Wisser">
+			<organization>ICANN</organization>
 			<address>
 				<email>ulrich@wisser.se</email>
 			</address>
@@ -50,7 +51,7 @@
 			</address>
 		</author>
 
-		<date day="4" month="4" year="2024"/>
+		<date day="8" month="6" year="2026"/>
 
 		<area>Operations and Management Area</area>
 		<workgroup>Domain Name System Operations (dnsop)</workgroup>
@@ -63,14 +64,15 @@
 		<abstract>
 			<t>
 				This document describes an algorithm and protocol to
-				automate the setup, operations, and decomissioning of
+				automate the setup, operations, and decommissioning of
 				<xref target="RFC8901">Multi-Signer DNSSEC</xref>
-				configurations. It employs Model 2 of the multi-signer
-				specification, where each operator has their own distinct
-				KSK and ZSK sets (or CSK sets),
-				<xref target="RFC8078">Managing DS Records from the Parent via
-				CDS/CDNSKEY</xref>, and <xref target="RFC7477">Child-to-Parent
-				Synchronization in DNS</xref> to accomplish this.
+				configurations. To accomplish this, it employs Model 2 of
+				the multi-signer specification (where each operator has
+				their own distinct KSK and ZSK sets, or CSK sets), management
+				of DS records from the parent via
+				<xref target="RFC8078">CDS/CDNSKEY</xref>, and
+				<xref target="RFC7477">Child-to-Parent Synchronization in
+				DNS</xref>.
 			</t>
 		</abstract>
 
@@ -91,13 +93,13 @@
 				multi-signer DNSSEC configuration. In this document we will combine
 				<xref target="RFC8901" /> with <xref target="RFC8078" /> and
 				<xref target="RFC7477" /> to define an automatable algorithm for
-				setting up, operating and decomissioning of a multi-signer
+				setting up, operating, and decommissioning a multi-signer
 				DNSSEC configuration.
 			</t>
 			<t>
 				One of the special cases of multi-signer DNSSEC is the secure
-				change of DNS operator. Using multi-signer Model 2 the secure change
-				of DNS operator can be accomplished.
+				change of DNS operator. Multi-signer Model 2 enables secure
+				changes of the DNS operator.
 			</t>
 			<section numbered="true" toc="default">
 				<name>Out-Of-Scope</name>
@@ -136,7 +138,7 @@
 			<t><strong>DS-Wait-Time</strong></t>
 			<t>
 				Once the parent has picked up and published the new DS record
-				set, the any further changes MUST to be delayed until the
+				set, any further changes MUST be delayed until the
 				new DS set has propagated.
 			</t>
 			<t>
@@ -145,10 +147,10 @@
 			<t><strong>DNSKEY-Wait-Time</strong></t>
 			<t>
 				Once the DNSKEY sets of all signers are updated, any further changes
-				MUST to be delayed until the new DNSKEY set has propagated.
+				MUST be delayed until the new DNSKEY set has propagated.
 			</t>
 			<t>
-				The minimum DNSKEY-Wait-Time is the maximum of all DNSKEYS TTL
+				The minimum DNSKEY-Wait-Time is the maximum of all DNSKEY TTL
 				values from all signers plus the time it takes to publish the zone on
 				all secondaries.
 			</t>
@@ -173,7 +175,7 @@
 			</t>
 			<t>
 				In this document we describe, except for the initial trust, how
-				the steps in the multi-migner DNSSEC setup can be automated.
+				the steps in the multi-signer DNSSEC setup can be automated.
 			</t>
 			<section numbered="true" toc="default">
 				<name>Secure Nameserver Operator Transition</name>
@@ -190,15 +192,15 @@
 					Multi-signer DNSSEC Model 2 provides a mechanism for transitioning
 					from one nameserver operator to another without "going insecure".
 					A new operator joins the current operator in a temporary
-					multi-signer group. Once that is accomplished and stable the old
-					operator leaves the multi-signer group completing the transition.
+					multi-signer group. Once that is accomplished and stable, the old
+					operator leaves the multi-signer group, completing the transition.
 				</t>
 			</section>
 			<section numbered="true" toc="default">
-				<name>Permanent multi-signer Operations</name>
+				<name>Permanent multi-signer operations</name>
 				<t>
 					Using multiple DNS providers to distribute authoritative DNS service
-					with each provider signing independendly and with their own key set.
+					with each provider signing independently and with their own key set.
 					This use-case is described in <xref target="RFC8901" />.
 				</t>
 			</section>
@@ -219,7 +221,7 @@
 				</t>
 				<t>
 					The controller needs to have authorized access to all signers.
-					This can be achieved in a variety of different ways. For example will many
+					This can be achieved in a variety of different ways. For example, many
 					service providers offer access through a REST API. Another possibility
 					is access through Dynamic Update <xref target="RFC2136" /> with TSIG authentication.
 				</t>
@@ -227,9 +229,9 @@
 			<section anchor="decentralized" numbered="true" toc="default">
 				<name>Decentralized</name>
 				<t>
-					In the decentralized models all signers will communicate with
-					each other and execute the necessary steps on their instance
-					only. For this signers need a specialized protocol to
+					In the decentralized model all signers communicate with
+					each other and execute the necessary steps on their own
+					instance. For this, signers need a specialized protocol to
 					communicate configuration details that are not part of
 					the zone data.
 				</t>
@@ -237,7 +239,7 @@
 			<section anchor="capabilities" numbered="true" toc="default">
 				<name>Capabilities</name>
 				<t>
-					In order for any of the models to work the signer must
+					In order for any of the models to work, the signer must
 					support the following capabilities.
 				</t>
 				<ol>
@@ -254,7 +256,7 @@
 		<section anchor="algo" numbered="true" toc="default">
 			<name>Algorithms</name>
 			<t>
-				In a centralized model it is the controllers task to compute all waiting times and
+				In a centralized model it is the controller's task to compute all waiting times and
 				control the zone in a way that all timing restrictions are met.
 			</t>
 			<t>
@@ -262,14 +264,14 @@
 				all timing restrictions.
 			</t>
 			<t>
-				In both methods it will be necessary that some of the timing restrictions must be given
+				In both methods, some of the timing restrictions must be specified
 				as part of the configuration data.
 			</t>
 			<section numbered="true" toc="default">
 				<name>Prerequisites</name>
 				<t>Each signer to be added, including the initial signer, must
 					meet the following prerequisites before joining the multi-signer
-					Group
+					group:
 				</t>
 				<ol>
 					<li>
@@ -281,7 +283,7 @@
 					</li>
 					<li>
 						Signer or controller must be able to differentiate between its own keys and
-						keys from others signers.
+						keys from other signers.
 					</li>
 					<li>
 						Signer or controller must be able to differentiate between NS records that
@@ -290,7 +292,7 @@
 					</li>
 					<li>
 						If the domain is not covered by a CDS/CDNSKEY scanner and a
-						CSYNC scanner updates to the parent zone have to be
+						CSYNC scanner, updates to the parent zone have to be
 						made manually.
 					</li>
 				</ol>
@@ -299,10 +301,10 @@
 				<name>Setting up a new multi-signer group</name>
 				<t>
 					The zone is already authoritatively served by one DNS operator and is DNSSEC signed.
-					For full automation both the KSK and ZSK or CSK must be online.
+					For full automation, both the KSK and ZSK (or CSK) must be online.
 				</t>
 				<t>
-					This would be a special case, a multi-signer group with only one signer.
+					This is a special case: a multi-signer group with only one signer.
 				</t>
 			</section>
 			<section numbered="true" toc="default">
@@ -323,7 +325,7 @@
 						in the multi-signer group.
 					</li>
 					<li>
-						Configure all signers with the compiled CDS/CDNSKEY RRSET.
+						Configure all signers with the compiled CDS/CDNSKEY RRset.
 					</li>
 					<li>
 						Wait for Parent to publish the combined DS RRset.
@@ -332,18 +334,18 @@
 						Remove CDS/CDNSKEY Records from all signers. (optional)
 					</li>
 					<li>
-						Wait maximum of DS-Wait-Time and DNSKEY-Wait-Time
+						Wait for the maximum of DS-Wait-Time and DNSKEY-Wait-Time.
 					</li>
 					<li>
-						Compile NS RRSET including all NS records from all
+						Compile NS RRset including all NS records from all
 						signers.
 					</li>
 					<li>
-						Configure all signers with the compiled NS RRSET.
+						Configure all signers with the compiled NS RRset.
 					</li>
 					<li>
-						Compare NS RRSET of the signers to the Parent, if there is a
-						difference publish CSYNC record with NS and A and AAAA bit
+						Compare NS RRset of the signers to the Parent. If there is a
+						difference, publish a CSYNC record with the NS, A, and AAAA bits
 						set on all signers.
 					</li>
 					<li>
@@ -361,18 +363,18 @@
 						Remove exiting signer's NS records from remaining signers
 					</li>
 					<li>
-						Compare NS RRSET of the signers to the Parent, if there
-						is a difference publish CSYNC record with NS and A and AAAA
-						bit set on remaining signers.
+						Compare NS RRset of the signers to the Parent. If there
+						is a difference, publish a CSYNC record with the NS, A, and AAAA
+						bits set on the remaining signers.
 					</li>
 					<li>
-						Wait for Parent to publish NS RRSET.
+						Wait for Parent to publish NS RRset.
 					</li>
 					<li>
 						Remove CSYNC record from all signers. (optional)
 					</li>
 					<li>
-						Wait NS-Wait-Time
+						Wait for NS-Wait-Time.
 					</li>
 					<li>
 						Stop the exiting signer from answering queries.
@@ -383,7 +385,7 @@
 					</li>
 					<li>
 						Configure remaining signers with the compiled
-						CDS/CDNSKEY RRSET.
+						CDS/CDNSKEY RRset.
 					</li>
 					<li>
 						Remove ZSK/CSK of the exiting signer from remaining signers.
@@ -406,7 +408,7 @@
 						Update all signers with the new ZSK.
 					</li>
 					<li>
-						Wait DNSKEY-Wait-Time
+						Wait for DNSKEY-Wait-Time.
 					</li>
 					<li>
 						Signer can start using the new ZSK.
@@ -421,13 +423,13 @@
 				</ol>
 			</section>
 			<section>
-				<name>A Signer performs a CSK or KSK rollover</name>
+				<name>A signer performs a CSK or KSK rollover</name>
 				<ol>
 					<li>
 						Signer publishes new CSK / KSK in its own DNSKEY RRset.
 					</li>
 					<li>
-						In case of CSK, add CSK to DNSKEY set of all other signers.
+						In the case of a CSK, add CSK to DNSKEY set of all other signers.
 					</li>
 					<li>
 						Signer signs DNSKEY RRset with old and new CSK / KSK.
@@ -436,26 +438,26 @@
 						Calculate new CDS/CDNSKEY RRset and publish on all signers.
 					</li>
 					<li>
-						Wait for parent to pickup and publish new DS RR set.
+						Wait for Parent to pick up and publish the new DS RRset.
 					</li>
 					<li>
-						Wait DS-Wait-Time + DNSKEY-Wait-Time
+						Wait for DS-Wait-Time + DNSKEY-Wait-Time.
 					</li>
 					<li>
-						Signer removes old CSK/KSK from its DNSKEY RR set. And removes all
-						signatures done with this key.
+						Signer removes old CSK/KSK from its DNSKEY RRset, and removes all
+						signatures made with this key.
 					</li>
 					<li>
-						In case  of CSK, remove old CSK from DNSKEY set of all other signers.
+						In the case of a CSK, remove old CSK from DNSKEY set of all other signers.
 					</li>
 					<li>
 						Calculate new CDS/CDNSKEY RRset and publish on all signers.
 					</li>
 					<li>
-						Wait for parent to pickup and publish new DS RR set.
+						Wait for Parent to pick up and publish the new DS RRset.
 					</li>
 					<li>
-						Remove CDS/CDNSKEY RR sets from all signers.
+						Remove CDS/CDNSKEY RRsets from all signers.
 					</li>
 				</ol>
 			</section>
@@ -472,22 +474,22 @@
 						Calculate new CDS/CDNSKEY RRset and publish on all signers.
 					</li>
 					<li>
-						Wait for parent to pickup and publish new DS RR set.
+						Wait for Parent to pick up and publish the new DS RRset.
 					</li>
 					<li>
-						Wait DS-Wait-Time + DNSKEY-Wait-Time
+						Wait for DS-Wait-Time + DNSKEY-Wait-Time.
 					</li>
 					<li>
-						Removes all keys and signatures which are using the old algorithm.
+						Remove all keys and signatures that use the old algorithm.
 					</li>
 					<li>
 						Calculate new CDS/CDNSKEY RRset and publish on all signers.
 					</li>
 					<li>
-						Wait for parent to pickup and publish new DS RR set.
+						Wait for Parent to pick up and publish the new DS RRset.
 					</li>
 					<li>
-						Remove CDS/CDNSKEY RR sets from all signers.
+						Remove CDS/CDNSKEY RRsets from all signers.
 					</li>
 				</ol>
 			</section>
@@ -524,9 +526,9 @@
 				algorithms should still validate.
 			</t>
 			<t>
-				This could be an acceptable risk in a situation where going insecure
-				is not desirable or impossible and name servers have to be changed
-				between operators which only support distinct set of key algorithms.
+				This could be an acceptable risk in situations where going insecure
+				is undesirable or impossible, and nameservers must be changed
+				between operators that only support disjoint sets of key algorithms.
 			</t>
 			<t>
 				We have to consider the following scenarios:
@@ -543,12 +545,12 @@
 			</t>
 			<t><strong>Validator supports only one of the algorithms</strong></t>
 			<t>
-				The validator will not be able to validate the DNSKEY RR set or
+				The validator will not be able to validate the DNSKEY RRset or
 				any data from one of the signers. So in some cases the validator
 				will consider the zone bogus and reply with a SERVFAIL response code.
 			</t>
 			<t>
-				The later scenario can be mitigated, but not fully eliminated, by
+				The latter scenario can be mitigated, but not fully eliminated, by
 				selecting two well-supported algorithms.
 			</t>
 		</section>
@@ -567,9 +569,9 @@
 			</t>
 			<t>
 				Independent of the chosen model, it is crucial that only authorized entities
-				will be able to change the zone data. Some providers or software installation allow to
-				make more specific configuration on the allowed changes. All extra steps to allow as little
-				access to change zone data as possible should be taken.
+				are able to change the zone data. Some providers or software installations allow
+				finer-grained configuration of which changes are permitted. Access to modify
+				zone data should be restricted as much as possible.
 			</t>
 			<t>
 				If used correctly, the multi-signer algorithm will strengthen the DNS security
@@ -579,12 +581,12 @@
 		<section anchor="implementation" numbered="true" toc="default">
 			<name>Implementation Status</name>
 			<t>
-				One implementation of a centralized controller which supports updates
-			  through Dynamic DNS or REST API's of several vendors has been implemented
-				by the Swedish Internet Foundation.
+				The Swedish Internet Foundation has implemented a centralized
+				controller that supports updates via Dynamic DNS or the REST APIs
+				of several vendors.
 			</t>
 			<t>
-				The code can be found as part of the multi-signer project on Github
+				The code can be found as part of the multi-signer project on GitHub
 				<eref target="https://github.com/DNSSEC-Provisioning/multi-signer-controller" />
 			</t>
 		</section>


### PR DESCRIPTION
  - Fix typos: decommissioning, multi-signer, independently, GitHub, REST APIs, latter scenario, pick up (verb)
  - Fix grammar: "MUST to be", "the any", missing apostrophes, imperative verb forms in algorithm step lists
  - Add missing commas after introductory phrases; fix two comma splices in the "Compare NS RRset … publish CSYNC record" steps
  - Rewrite awkward/non-idiomatic phrasing: abstract list parallelism, Germanic V2 word order, "allow to make", "implementation has been implemented"
  - Normalize RRset spelling (was RRSET / RR set / RR sets), Parent capitalization in algorithm steps, "Wait for [the] X" phrasing, multi-signer / section-title casing